### PR TITLE
Add models to excluded list

### DIFF
--- a/src/scicloj/sklearn_clj/ml.clj
+++ b/src/scicloj/sklearn_clj/ml.clj
@@ -77,7 +77,8 @@
              (filter #(not (contains?
                             #{"MultiOutputRegressor" "RegressorChain" "StackingRegressor" "VotingRegressor"
                               "ClassifierChain" "MultiOutputClassifier" "OneVsOneClassifier" "OneVsRestClassifier"
-                              "OutputCodeClassifier" "StackingClassifier" "VotingClassifier"}
+                              "OutputCodeClassifier" "StackingClassifier" "VotingClassifier" "FixedThresholdClassifier"
+                              "TunedThresholdClassifierCV"}
                             (:class-name %)))))]
 
     (run!


### PR DESCRIPTION
FixedThresholdClassifier and TunedThresholdClassifierCV require an estimator in the constructor and need to be excluded so that the latest scikit-learn 1.5.1 library can be used. 